### PR TITLE
MINOR: BlogPost: Sets Title label to "Post Title"

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -14,6 +14,7 @@ en:
     Categories: 'Categories'
     Tags: 'Tags'
     FeaturedImage: 'Featured Image'
+    PageTitleLabel: 'Post Title'
   Blog:
     BlogPosts: 'Blog Posts'
     Categories: 'Categories'

--- a/model/BlogPost.php
+++ b/model/BlogPost.php
@@ -176,6 +176,19 @@ class BlogPost extends Page {
 		return Controller::join_links($this->Parent()->Link("archive"), $date->format("Y"));
 	}
 
+
+
+	/**
+	 * Sets the label for BlogPost.Title to 'Post Title' (Rather than 'Page name')
+	 *
+	 * @return array
+	**/
+	public function fieldLabels($includerelations = true) {   
+		$labels = parent::fieldLabels($includerelations);
+		$labels['Title'] = _t('BlogPost.PageTitleLabel', "Post Title");      
+		return $labels;
+	}
+
 }
 
 


### PR DESCRIPTION
Instead of the slightly confusing "Page name". Takes effect in the EditForm, as well as in the BlogPosts Gridfield.
