### PR TITLE
Update the PublishDate on first Publish

### DIFF
--- a/model/BlogPost.php
+++ b/model/BlogPost.php
@@ -110,9 +110,9 @@ class BlogPost extends Page {
 	 * Update the PublishDate to now, if being published for the first time, and the date hasn't been set to the future.
 	**/
 	public function onBeforePublish() {
-		if ($this->owner->obj('PublishDate')->InPast() && !$this->owner->isPublished()) {
-			$this->owner->setCastedField("PublishDate", time());
-			$this->owner->write();
+		if ($this->dbObject('PublishDate')->InPast() && !$this->isPublished()) {
+			$this->setCastedField("PublishDate", time());
+			$this->write();
 		}
 	}
 


### PR DESCRIPTION
Currently, if a user does the following:
1. Creates a new post
2. Spends a couple of days/weeks writing the post
3. Publishes the post

The date for "Published on" ends up being the date the post was originally created, and not when the post was actually published.

This commit resolves this issue by updating the PublishDate to 'now' when the post is first published. It only does this if the PublishDate is in the past to avoid updating it when the user has manually specified for the post to be published at a later set date.
