### PR TITLE
Blog: Sets 'Blog Posts' as the 1st CMS tab

### DIFF
--- a/model/Blog.php
+++ b/model/Blog.php
@@ -34,6 +34,8 @@ class Blog extends Page {
 
 	public function getCMSFields() {
 		$this->beforeUpdateCMSFields(function($fields) {
+
+			$fields->insertBefore(new Tab('BlogPosts'), 'Main');
 		
 			$posts = $this->getBlogPosts();
 			$excluded = $this->getExcludedSiteTreeClassNames();


### PR DESCRIPTION
As the most used and most important tab, it deserves to be the first one so users have instant access to their list of posts. :)

P.S. Sorry for the influx of PRs! If you haven't guessed, I'm putting together a SilverStripe blog package, that centres around your excellent module. It's mainly designed for use on sites for my clients, and it includes all the main modules, plus a bunch of custom tweaks to further polish the experience of each one. I've been PRing any tweaks that I feel fit best in the core.

You can see my package and list of included tweaks here: https://github.com/purplespider/silverstripe-mypswd-blog-tweaks

More than happy to create PRs for any tweaks listed that you feel would make sense in the core.

Thanks again!
