### PR TITLE
Blog: "Blog Posts" is the first tab, only once Blog page is published

### DIFF
--- a/model/Blog.php
+++ b/model/Blog.php
@@ -34,6 +34,11 @@ class Blog extends Page {
 
 	public function getCMSFields() {
 		$this->beforeUpdateCMSFields(function($fields) {
+
+			// Sets Blog Posts tab 1st once published
+			if ($this->isPublished()) {
+				$fields->insertBefore(new Tab('BlogPosts'), 'Main');
+			}
 		
 			$posts = $this->getBlogPosts();
 			$excluded = $this->getExcludedSiteTreeClassNames();


### PR DESCRIPTION
If the Blog page is not yet published, then "Main Content" is the default tab. Once the page is published, then the "Blog Posts" tab becomes the default tab for faster access.
