### PR TITLE
BUG Unused variable put to use. Doesn't show future posts on live stage

### DIFF
--- a/extensions/BlogPostFilter.php
+++ b/extensions/BlogPostFilter.php
@@ -15,15 +15,10 @@ class BlogPostFilter extends DataExtension {
 	 * Augment queries so that we don't fetch unpublished articles.
 	**/
 	public function augmentSQL(SQLQuery &$query) {
-
-		if(!Permission::check("VIEW_DRAFT_CONTENT")) {
-			$stage = Versioned::current_stage();
-			if($stage == "Stage") $stage = "";
-			else $stage = "_" . Convert::raw2sql($stage);
-
+		$stage = Versioned::current_stage();
+		if($stage == 'Live' || !Permission::check("VIEW_DRAFT_CONTENT")) {
 			$query->addWhere("PublishDate < '" . Convert::raw2sql(SS_Datetime::now()) . "'");
-		} 
-
+		}
 	}
 
 	/**

--- a/tests/BlogTest.php
+++ b/tests/BlogTest.php
@@ -58,37 +58,37 @@ class BlogTest extends SapphireTest {
 		$response = Director::test($archiveLink);
 		$this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
 
-		// $archiveLink = Controller::join_links($blog->Link("archive"), 2013, 10);
-		// $response = Director::test($archiveLink);
-		// $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
+		 $archiveLink = Controller::join_links($blog->Link("archive"), 2013, 10);
+		 $response = Director::test($archiveLink);
+		 $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
 
-		// $archiveLink = Controller::join_links($blog->Link("archive"), 2013);
-		// $response = Director::test($archiveLink);
-		// $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
+		 $archiveLink = Controller::join_links($blog->Link("archive"), 2013);
+		 $response = Director::test($archiveLink);
+		 $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
 
-		// $archiveLink = Controller::join_links($blog->Link("archive"), 2011, 10, 01);
-		// $response = Director::test($archiveLink); // No posts on this date, but a valid entry.
-		// $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
+		 $archiveLink = Controller::join_links($blog->Link("archive"), 2011, 10, 01);
+		 $response = Director::test($archiveLink); // No posts on this date, but a valid entry.
+		 $this->assertEquals(200, $response->getStatusCode(), "HTTP Status should be 200");
 
 
-		// // Test invalid links & dates
-		// $response = Director::test($blog->Link("archive")); // 404 when no date is set
-		// $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
+		 // Test invalid links & dates
+		 $response = Director::test($blog->Link("archive")); // 404 when no date is set
+		 $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
 
-		// // Invalid year
-		// $archiveLink = Controller::join_links($blog->Link("archive"), "invalid-year");
-		// $response = Director::test($archiveLink); // 404 when an invalid yer is set
-		// $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
+		 // Invalid year
+		 $archiveLink = Controller::join_links($blog->Link("archive"), "invalid-year");
+		 $response = Director::test($archiveLink); // 404 when an invalid yer is set
+		 $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
 
-		// // Invalid month
-		// $archiveLink = Controller::join_links($blog->Link("archive"), "2013", "99");
-		// $response = Director::test($archiveLink); // 404 when an invalid month is set
-		// $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
+		 // Invalid month
+		 $archiveLink = Controller::join_links($blog->Link("archive"), "2013", "99");
+		 $response = Director::test($archiveLink); // 404 when an invalid month is set
+		 $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
 
-		// // Invalid day
-		// $archiveLink = Controller::join_links($blog->Link("archive"), "2013", "10", "99");
-		// $response = Director::test($archiveLink); // 404 when an invalid day is set
-		// $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
+		 // Invalid day
+		 $archiveLink = Controller::join_links($blog->Link("archive"), "2013", "10", "99");
+		 $response = Director::test($archiveLink); // 404 when an invalid day is set
+		 $this->assertEquals(404, $response->getStatusCode(), "HTTP Status should be 404");
 
 	}
 


### PR DESCRIPTION
This fixes #36 

The ensures the future blog posts don't get shown in the live stage, even for users who are able to see draft content.
